### PR TITLE
Fixes for 1.4

### DIFF
--- a/source/extensions/transport_sockets/tls/BUILD
+++ b/source/extensions/transport_sockets/tls/BUILD
@@ -67,7 +67,7 @@ envoy_cc_library(
         "//source/common/secret:sds_api_lib",
         "//source/common/ssl:certificate_validation_context_config_impl_lib",
         "//source/common/ssl:tls_certificate_config_impl_lib",
-        "@envoy_api//envoy/api/v2/auth:cert_cc",
+        "@envoy_api//envoy/api/v2/auth:pkg_cc_proto",
     ],
 )
 
@@ -99,7 +99,7 @@ envoy_cc_library(
         "//source/common/common:hex_lib",
         "//source/common/common:utility_lib",
         "//source/common/protobuf:utility_lib",
-        "@envoy_api//envoy/admin/v2alpha:certs_cc",
+        "@envoy_api//envoy/admin/v2alpha:pkg_cc_proto",
     ],
 )
 


### PR DESCRIPTION
This PR fixes a variety of build failures for 1.4: 
* Moved off of Bill's fork of envoy-openssl (pre-patch) onto one hosted on the Maistra repo.
* Multiple matches for replace_text silently fails. With the changes in this PR, if multiple matches are detected, the script will error and exit, notifying the user that it needs to be fixed. 
* Fixes for dependencies in source/common/crypto/BUILD -- The text in this file no longer includes the words "ssl" as it did previously. Instead, we now create an external_deps section after the name. 
* Fixes for _boringssl_fips in repositories.bzl to remove invalid references to removed dependencies from repositories_list.bzl
* Fixes due to the fact that certs_cc and cert_cc were renamed here: https://github.com/envoyproxy/envoy/commit/4e858f17fe08224c9c089240908ccd0c518e01a7#diff-3d269e2e2f23710515cf81b17c430d1b
```